### PR TITLE
ascs: Fix possible NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -329,10 +329,16 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
 	struct bt_audio_stream *stream = ep->stream;
-	struct bt_audio_stream_ops *ops = stream->ops;
+	struct bt_audio_stream_ops *ops;
 
 	BT_DBG("stream %p ep %p reason 0x%02x", chan, ep, reason);
 
+	if (stream == NULL) {
+		/* No stream for endpoint */
+		return;
+	}
+
+	ops = stream->ops;
 	if (ops != NULL && ops->stopped != NULL) {
 		ops->stopped(stream);
 	} else {


### PR DESCRIPTION
This fixes exception that might happen when the CIS is disconnected
locally as the one of the steps performed in `Releasing` state.
The function that is called then, bt_audio_stream_detach sets ep->stream
to NULL and when we receive HCI Disconnected event with CIS handle (the
one for witch we already cleaned up endpoint) we hit this NULL pointer
dereference.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>